### PR TITLE
♻️Refactor (86a7w2t44): Replacing cookies with authorization header

### DIFF
--- a/src/lib/api/authApi.tsx
+++ b/src/lib/api/authApi.tsx
@@ -1,45 +1,101 @@
-import axios from 'axios';
+import axios from "axios";
+
+const ACCESS_TOKEN_KEY = "accessToken";
+const REFRESH_TOKEN_KEY = "refreshToken";
+
+export function setTokens({
+  accessToken,
+  refreshToken,
+}: {
+  accessToken: string;
+  refreshToken: string;
+}) {
+  localStorage.setItem(ACCESS_TOKEN_KEY, accessToken);
+  localStorage.setItem(REFRESH_TOKEN_KEY, refreshToken);
+  // Actualiza header por defecto
+  authApi.defaults.headers.common["Authorization"] = `Bearer ${accessToken}`;
+}
+
+export function clearTokens() {
+  localStorage.removeItem(ACCESS_TOKEN_KEY);
+  localStorage.removeItem(REFRESH_TOKEN_KEY);
+  delete authApi.defaults.headers.common["Authorization"];
+}
+export function getAccessToken() {
+  return localStorage.getItem(ACCESS_TOKEN_KEY);
+}
+
+export function getRefreshToken() {
+  return localStorage.getItem(REFRESH_TOKEN_KEY);
+}
 
 export const authApi = axios.create({
-    baseURL: import.meta.env.VITE_BACKEND_URL,
-    // Para enviar y recibir cookies httpOnly
-    withCredentials: true,
+  baseURL: import.meta.env.VITE_BACKEND_URL,
+  // Para enviar y recibir cookies httpOnly
+  // withCredentials: true,
 });
 
+// ——————————————
+// Interceptor de petición
+// ——————————————
 authApi.interceptors.request.use(
-    config => config,
-    error => Promise.reject(error)
+  (config) => {
+    const token = getAccessToken();
+    if (token) {
+      config.headers = config.headers ?? {};
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+    return config;
+  },
+  (error) => Promise.reject(new Error(error.message ?? "Request error"))
 );
 
+authApi.interceptors.request.use(
+  (config) => config,
+  (error) => Promise.reject(new Error(error.message ?? "Request error"))
+);
+
+// ——————————————
+// Interceptor de respuesta para Refresh Token
+// ——————————————
 authApi.interceptors.response.use(
-    response => response,
-    async (error) => {
-        const originalRequest = error.config;
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config;
 
-        // Verificamos si es 401 y no estamos en /auth/refresh, y si no hemos reintentado ya (_retry).
-        if (
-            error.response &&
-            error.response.status === 401 &&
-            originalRequest.url !== '/auth/refresh' &&
-            !originalRequest._retry
-        ) {
-            originalRequest._retry = true;
-            try {
-                // Intenta refrescar el token:
-                await authApi.post('/auth/refresh');
+    // Si es 401 y no venimos de /auth/refresh ni hemos reintentado ya:
+    if (
+      error.response?.status === 401 &&
+      originalRequest.url !== "/auth/refresh" &&
+      !originalRequest._retry
+    ) {
+      originalRequest._retry = true;
+      try {
+        const refreshToken = getRefreshToken();
+        if (!refreshToken) throw new Error("No hay refresh token");
 
-                // Reintenta la petición original con el token ya refrescado
-                return authApi(originalRequest);
-            } catch (refreshError) {
-                return Promise.reject(refreshError);
-            }
-        }
+        // Pedimos nuevos tokens al backend
+        const { data } = await authApi.post("/auth/refresh", null, {
+          headers: {
+            Authorization: `Bearer ${refreshToken}`,
+          },
+        });
 
-        // Muestra en consola solo los errores que no sean 401 (para no spamear en el flujo esperado de "no logueado")
-        if (error.response && error.response.status !== 401) {
-            console.error('API Error:', error);
-        }
+        // Guardamos los nuevos tokens
+        setTokens({
+          accessToken: data.accessToken,
+          refreshToken: data.refreshToken,
+        });
 
-        return Promise.reject(error);
+        // Actualizamos el header de la petición original y la reintentamos
+        originalRequest.headers.Authorization = `Bearer ${data.accessToken}`;
+        return authApi(originalRequest);
+      } catch (refreshError) {
+        clearTokens();
+        return Promise.reject(refreshError instanceof Error ? refreshError : new Error(String(refreshError)));
+      }
     }
+
+    return Promise.reject(error instanceof Error ? error : new Error(String(error)));
+  }
 );

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -1,17 +1,35 @@
-import { authApi } from '../lib/api/authApi';
+// src/services/auth.ts
+
+import { authApi, setTokens, clearTokens } from '../lib/api/authApi';
 import { LoginInput, LoginResponse } from '../types';
 
+export const login = async (
+  credentials: LoginInput
+): Promise<{ userType: string }> => {
+  // 1) Hacemos la llamada al servidor
+  const { data } = await authApi.post<LoginResponse>(
+    '/auth/login',
+    credentials
+  );
 
-export const login = async (credentials: LoginInput): Promise<{ userType: string }> => {
-    const { data } = await authApi.post<LoginResponse>('/auth/login', credentials);
-    return { userType: data.userType };
+  // 2) Almacenamos ambos tokens (access + refresh)
+  setTokens({
+    accessToken: data.accessToken,
+    refreshToken: data.refreshToken,
+  });
+
+  return { userType: data.userType };
 };
 
 export const getSession = async (): Promise<{ userType: string }> => {
-    const { data } = await authApi.get("/auth/me")
-    return { userType: data.userType }
-}
+  // El interceptor ya pone el header Authorization con el accessToken guardado
+  const { data } = await authApi.get<{ userType: string }>('/auth/me');
+  return { userType: data.userType };
+};
 
-export const logout = async () => {
-    await authApi.post("/auth/logout")
-}
+export const logout = async (): Promise<void> => {
+  // 1) Avisamos al backend (opcional, según tu flujo)
+  await authApi.post('/auth/logout');
+  // 2) Borramos los tokens localmente
+  clearTokens();
+};

--- a/src/types/authType.ts
+++ b/src/types/authType.ts
@@ -5,5 +5,7 @@ export interface LoginInput {
 
 export interface LoginResponse {
     userType: string;
+    accessToken: string;
+    refreshToken: string;
 }
 


### PR DESCRIPTION
## Description:

This PR updates the frontend to handle authentication with Bearer tokens. Axios is configured with interceptors that automatically attach the access token to requests and handle token refresh on 401 responses. Helper functions manage token storage in localStorage.

## Changes:

* authApi.ts
Exported helper functions: setTokens, clearTokens, getAccessToken, getRefreshToken.
Configured request interceptor to inject Authorization: Bearer <accessToken> header.
Configured response interceptor to catch 401 errors, call /auth/refresh using the refresh token, update stored tokens, and retry the original request.

* auth.ts
Updated login to call setTokens with accessToken and refreshToken after successful login.
getSession now relies on the Axios interceptor to include the access token.
logout calls /auth/logout and then clears tokens via clearTokens.