### PR TITLE
🐛 fix: AuthContext with user refresh functionality and test completion handling

### DIFF
--- a/src/components/screens/StudentGradesScreen.tsx
+++ b/src/components/screens/StudentGradesScreen.tsx
@@ -1,21 +1,21 @@
-// pages/student-grades.tsx
 import { useRef } from "react";
-import type { NextPage } from "next";
 import { Button } from "@/components/atoms/ui/button";
 import { GradesFormTemplate } from "@/components/templates/GradesFormTemplate";
 import type { DynamicFormHandles } from "@/components/molecules/Dynamic-form";
-import { usePatchGradesResult } from "@/hooks/";
+import { useUpdateMyUser, usePatchGradesResult } from "@/hooks/";
 import type { GradeFormType } from "@/types/gradeFormType";
 import { useNavigate } from "react-router-dom";
 import { notifySuccess } from "@/lib/utils/notify";
+import { useAuthContext } from "@/context/AuthContext";
 
-
-const StudentGradesScreen: NextPage = () => {
+export default function StudentGradesScreen() {
   const navigate = useNavigate(); const formRef = useRef<DynamicFormHandles>(null);
-    const { submit, loading, error } = usePatchGradesResult();
+  const { submit, loading, error } = usePatchGradesResult();
+  const { mutateAsync: updateUser } = useUpdateMyUser();
+  const { refreshUser } = useAuthContext();
+
 
   const handleFormSubmit = async (values: Record<string, any>) => {
-    // Mapear al DTO que espera tu backend
     const payload: GradeFormType = {
       zone: values.zone,
       locality: values.locality,
@@ -29,13 +29,20 @@ const StudentGradesScreen: NextPage = () => {
 
     try {
       await submit(payload);
-      navigate("/student-vocationalTest");
       notifySuccess({
         title: "Perfecto!",
         description: "Tus notas se han guardado.",
         icon: "✅",
         closeButton: true,
       });
+      const updateTestCompleted = {
+      testCompleted: true,
+    };
+
+      await updateUser(updateTestCompleted);
+
+      await refreshUser();
+      navigate("/student-vocationalTest");
     } catch (err) {
       console.error("Error al enviar el formulario:", err);
     }
@@ -70,5 +77,3 @@ const StudentGradesScreen: NextPage = () => {
     </div>
   );
 };
-
-export default StudentGradesScreen;

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -18,6 +18,7 @@ interface IAuthContext {
   logout: () => Promise<void>;
   createAccount: (userData: unknown) => Promise<void>;
   registryAccount: (userData: unknown) => Promise<void>;
+  refreshUser: () => Promise<void>;
 }
 
 const AuthContext = createContext<IAuthContext | undefined>(undefined);
@@ -32,32 +33,28 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
   
 
 
-  useEffect(() => {
-    checkSession();
-  }, []);
-
   const checkSession = async () => {
+    setIsAuthLoading(true);           // marcamos loading al inicio
     try {
-      const data = await getSession();
-      setUserType(data.userType);
-      
-      const loadUser = async () => {
-        try {
-          const user = await fetchUser();
-          setUser(user);
-        } catch (error) {
-          console.error("Error fetching user data:", error);
-        }
-      }
-      loadUser();;
+      // 1) verificamos sesión
+      const session = await getSession();
+      setUserType(session.userType);
 
+      // 2) esperamos a que llegue el user con testCompleted
+      const me = await fetchUser();
+      setUser(me);
     } catch {
       setUserType(null);
       setUser(null);
     } finally {
-      setIsAuthLoading(false);
+      setIsAuthLoading(false);        // sólo aquí, **tras** fetchUser
     }
   };
+
+  useEffect(() => {
+    checkSession();
+  }, []);
+
 
   const loginMutation = useMutation({
     mutationFn: ({ email, password }: { email: string; password: string }) =>
@@ -91,6 +88,15 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
     await registerMutation.mutateAsync({ ...userData });
   };
 
+   const refreshUser = async () => {
+    try {
+      const u = await fetchUser();
+      setUser(u);
+    } catch (err) {
+      console.error("Error al refrescar user:", err);
+    }
+  };
+
   const value: IAuthContext = {
     user,
     userType,
@@ -99,6 +105,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
     logout,
     createAccount,
     registryAccount,
+    refreshUser,
   };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -12,6 +12,8 @@ export * from './user/useGetManagersByUniversityHook';
 export * from './user/useGetSupportByAdminHook';
 export * from './user/useGetFinanceByAdminHook';
 export * from './user/useGetMarketingByAdminHook';
+export * from './user/useGetMyUserHook';
+export * from './user/useUpdateMyUserHook';
 
 // Campaign hooks
 export * from './campaign/useCreateCampaignHook';

--- a/src/routes/StudentRoutes.tsx
+++ b/src/routes/StudentRoutes.tsx
@@ -1,12 +1,27 @@
-import { useAuthContext } from "@/context/AuthContext"
-import { Navigate, Outlet } from "react-router-dom"
+import { useAuthContext } from "@/context/AuthContext";
+import { Navigate, Outlet, useLocation } from "react-router-dom";
+// si tienes un componente de carga, úsalo aquí
+import { Spinner } from "@/components/atoms/Spinner";
 
 export default function StudentRoutes() {
-    const { userType } = useAuthContext()
+  const { user, userType, isAuthLoading } = useAuthContext();
+  const { pathname } = useLocation();
 
-    if (userType === "STUDENT") {
-        return <Outlet />
-    }
+  // 1. Mientras carga la sesión, mostramos spinner
+  if (isAuthLoading) {
+    return <Spinner />;
+  }
 
-    return <Navigate to="/auth" />
+  // 2. Sólo STUDENT puede entrar aquí
+  if (userType !== "STUDENT") {
+    return <Navigate to="/auth" replace />;
+  }
+
+  // 3. Si no ha completado el test y NO está ya en /student-grades, forzamos la ruta
+  if (!user?.testCompleted && pathname !== "/student-grades") {
+    return <Navigate to="/student-grades" replace />;
+  }
+
+  // 4. Si todo OK, renderizamos las rutas hijas
+  return <Outlet />;
 }

--- a/src/types/userType.ts
+++ b/src/types/userType.ts
@@ -10,6 +10,7 @@ export interface User {
     school?: string;
     preferences?: Record<string, unknown>;
     avatar?: string;
+    testCompleted?: boolean;
   }
   
   //excludes id when creating a new user


### PR DESCRIPTION
## Description
Workflow that blocks students from accessing any application routes until they finish the grades form.

- Refactored checkSession() to await the fetchUser() call before marking isAuthLoading = false. This guarantees that user.testCompleted is populated before any route-guard logic runs. 
- Also introduced a refreshUser() helper (exposed via context) to re-fetch the current user after updates.

## Modified Files

- src/components/screens/StudentGradesScreen.tsx
- src/context/AuthContext.tsx
- src/hooks/index.ts
- src/routes/StudentRoutes.tsx
- src/types/userType.ts